### PR TITLE
Fixed old "messages" link and updated it to "conversations"

### DIFF
--- a/derpinotify/js/background.js
+++ b/derpinotify/js/background.js
@@ -9,7 +9,7 @@
 	const NOTIF_ID = chrome.runtime.getManifest().name;
 	const LINKS = {
 		parseURL: '/pages/about',
-		messages: '/messages',
+		messages: '/conversations',
 		notifs: '/notifications',
 		signInPage: '/session/new',
 	};

--- a/derpinotify/manifest.json
+++ b/derpinotify/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Derpi-Notify",
-	"version": "1.2.6",
+	"version": "1.2.7",
 	"description": "Keep track of your Derpibooru notifications and messages in (almost) real time",
 	"applications": {
 		"gecko": {


### PR DESCRIPTION
Derpi changed the URL layout a while ago, just noticed that opening DMs doesn't work anymore. Fixed it by changing "messages" to "conversations" tho.